### PR TITLE
added updated useForm hook, bumped version

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@react-native-community",
+  "extends": "@react-native",
   "parser": "@typescript-eslint/parser",
   "plugins": ["@typescript-eslint", "import", "prettier"],
   "rules": {

--- a/README.md
+++ b/README.md
@@ -252,6 +252,12 @@ Flexible in its function, supports multiple validation approaches through callba
 2. To trigger standalone validation, use `validate("prop")`
 3. Validate entire form with `validateForm()`
 
+The order of importance when it comes to validating fields is:
+
+1. Custom validation rule - will get the value as-is for your rule to validate it fully. The configuration rule receives the current value, state and optional flag values for you to validate against.
+2. If there is no custom validation rule and the primitive value check returns false (there is no value), check if the field is optional. If optional, the validation result is `true`, otherwise it is `false`;
+3. If all previous checks have not been triggered, return the primitive "has value" check result. This will return `false` for values such as: `null | undefined | NaN | "" | Invalid Date`. This will return `true` if you have a complex value type such as `object | Array`, <b>so in case you have a complex value type use a custom validation rule to get what you need</b>.
+
 #### Example 1: Simple use case with standalone validation on blur:
 
 ```javascript
@@ -321,7 +327,7 @@ const { state, validation, update, validate } = useForm(
 	optional: ["middleName"],
 	// validation.lastName is invalid if lastName is <3 characters long
 	// state can be used to compare with other values (ie repeat password)
-	rules: { lastName: (value, state) => value.length >= 3,
+	rules: { lastName: (value, state, optional) => value.length >= 3,
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@prototyp/skeletor",
   "description": "React-Native UI and functional toolkit",
   "author": "Luka Buljan <luka@prototyp.digital>",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "types": "lib/typescript/src/index.d.ts",
   "main": "lib/module/index.js",
   "react-native": "src/index.ts",

--- a/src/hooks/useForm.ts
+++ b/src/hooks/useForm.ts
@@ -2,7 +2,11 @@ import { useEffect, useState } from "react";
 
 export type Validation<T> = { [K in keyof Partial<T>]?: boolean };
 type Rules<T> = {
-  [K in keyof T]?: (value: T[K], state: T) => boolean | undefined;
+  [K in keyof T]?: (
+    value: T[K],
+    state: T,
+    optional: boolean
+  ) => boolean | undefined;
 };
 
 export type Values<T> = {
@@ -148,17 +152,17 @@ export function useFormUtils<T>(config?: FormConfig<T>) {
     return true;
   }
 
+  function isOptional(key: keyof T) {
+    return config?.optional?.includes(key) || false;
+  }
+
   /** Validate by custom validation rule. If the rule does not exist, returns undefined. */
   function validateByRule<K extends keyof T>(
     key: K,
     value: T[K],
     state: Values<T>
   ) {
-    return config?.rules?.[key]?.(value, state);
-  }
-
-  function isOptional(key: keyof T) {
-    return config?.optional?.includes(key);
+    return config?.rules?.[key]?.(value, state, isOptional(key));
   }
 
   /** Handles validation for a specific form field.


### PR DESCRIPTION
- Updated field validation order of importance
  1. custom validation rule to preserve the original value type, allowing types such as `string | null`.
  2. primitive no value check -> check if optional field = if there is no value, return optional flag value (`true | false`)
  3. return primitive value check = if all other checks aren't triggered, return primitive if value exists result. This will return false for values such as: `null | undefined | NaN | "" | Invalid Date`. This will return true if you have a complex value type such as `object | Array`, so in case you have a complex value type use a custom validation rule to get what you need.

- Added primitive `Date = Invalid Date` value type check.
- Added `optional` value to validation rule callback, allowing you to `return optional` as it is in the useForm configuration object.

Note: This changes the order of importance when it comes to validating fields, because we no longer check if the value exists first, but rather check if a custom validation rule exists. If it does, it passes the value as-is (no falsy value check) so you can fully validate what you have. If it does not, it goes into optional / primitive has value checks. 