### PR TITLE
Updated border type to support all properties.

### DIFF
--- a/src/models/Border.ts
+++ b/src/models/Border.ts
@@ -1,17 +1,9 @@
-import { AnimatableNumericValue } from "react-native/types";
+import { ViewStyle } from "react-native/types";
+
+type BorderStyles = {
+  [Key in keyof ViewStyle]: Key extends `border${infer Rest}` ? Key : never;
+}[keyof ViewStyle];
 
 export interface Border {
-  border?: {
-    borderWidth?: number;
-    borderTopWidth?: number;
-    borderBottomWidth?: number;
-    borderLeftWidth?: number;
-    borderRightWidth?: number;
-    borderColor?: string;
-    borderRadius?: AnimatableNumericValue;
-    borderTopLeftRadius?: AnimatableNumericValue;
-    borderTopRightRadius?: AnimatableNumericValue;
-    borderBottomLeftRadius?: AnimatableNumericValue;
-    borderBottomRightRadius?: AnimatableNumericValue;
-  };
+  border?: BorderStyles;
 }


### PR DESCRIPTION
Adding support for `borderStyle` prop which works, but it is currently not properly supported by skeletor type system.

This change will extract all available properties from ViewStyle type which start with `border` keyword.

Summary:
- Added a type extractor which matches all properties from ViewStyle type which start with a `border` keyword.