### PR TITLE
Allow font scaling configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ interface SkeletorConfig {
   defaultFontSize: [number, number] | number;
   defaultStatusBarType: "dark-content" | "light-content" | "default";
   defaultTextColor: string;
+  /** Defaults to false */
+  allowFontScaling: boolean;
+  /** Defaults to 1 */
+  maxFontSizeMultiplier: number;
 }
 ```
 

--- a/src/components/SkeletorProvider/SkeletorContext.ts
+++ b/src/components/SkeletorProvider/SkeletorContext.ts
@@ -3,11 +3,13 @@ import React from "react";
 import type { SkeletorConfig } from "../../models";
 
 export const SkeletorDefaults: SkeletorConfig = {
-	defaultFont: undefined,
-	defaultFontSize: [12, 16],
-	defaultStatusBarType: "dark-content",
-	defaultTextColor: "black",
+  defaultFont: undefined,
+  defaultFontSize: [12, 16],
+  defaultStatusBarType: "dark-content",
+  defaultTextColor: "black",
+  allowFontScaling: false,
+  maxFontSizeMultiplier: 1,
 };
 
 export const SkeletorContext =
-	React.createContext<SkeletorConfig>(SkeletorDefaults);
+  React.createContext<SkeletorConfig>(SkeletorDefaults);

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -52,9 +52,11 @@ export const Text: React.FC<PropsWithChildren<TextProps>> = ({
   paddings,
   animations,
   gap,
+  allowFontScaling,
+  maxFontSizeMultiplier,
   ...props
 }) => {
-  const { defaultFont, defaultFontSize, defaultTextColor } = useSkeletor();
+  const skeletor = useSkeletor();
   const animationProps = useMemo(
     () => extractAnimationProperties(animations),
     [animations],
@@ -73,15 +75,15 @@ export const Text: React.FC<PropsWithChildren<TextProps>> = ({
       return { fontSize: value, lineHeight: value };
     }
 
-    return mapper(size || defaultFontSize);
-  }, [size, defaultFontSize]);
+    return mapper(size || skeletor.defaultFontSize);
+  }, [size, skeletor.defaultFontSize]);
 
   const styles = useMemo(
     () =>
       StyleSheet.flatten([
         {
-          color: color || defaultTextColor,
-          fontFamily: font || defaultFont,
+          color: color || skeletor.defaultTextColor,
+          fontFamily: font || skeletor.defaultFont,
           opacity,
           textAlign,
           textTransform,
@@ -110,8 +112,8 @@ export const Text: React.FC<PropsWithChildren<TextProps>> = ({
       sizeProps,
       flexProps,
       gapProps,
-      defaultTextColor,
-      defaultFont,
+      skeletor.defaultTextColor,
+      skeletor.defaultFont,
       letterSpacing,
     ],
   );
@@ -119,8 +121,10 @@ export const Text: React.FC<PropsWithChildren<TextProps>> = ({
   return (
     <Animated.Text
       style={[styles, animationProps]}
-      allowFontScaling={false}
-      maxFontSizeMultiplier={1}
+      allowFontScaling={allowFontScaling || skeletor.allowFontScaling}
+      maxFontSizeMultiplier={
+        maxFontSizeMultiplier || skeletor.maxFontSizeMultiplier
+      }
       {...props}
     >
       {children}

--- a/src/models/SkeletorConfig.ts
+++ b/src/models/SkeletorConfig.ts
@@ -3,6 +3,8 @@ export interface SkeletorConfig {
   defaultFontSize: [number, number] | number;
   defaultStatusBarType: "dark-content" | "light-content" | "default";
   defaultTextColor: string;
+  /** Defaults to false */
   allowFontScaling: boolean;
+  /** Defaults to 1 */
   maxFontSizeMultiplier: number;
 }

--- a/src/models/SkeletorConfig.ts
+++ b/src/models/SkeletorConfig.ts
@@ -3,4 +3,6 @@ export interface SkeletorConfig {
   defaultFontSize: [number, number] | number;
   defaultStatusBarType: "dark-content" | "light-content" | "default";
   defaultTextColor: string;
+  allowFontScaling: boolean;
+  maxFontSizeMultiplier: number;
 }


### PR DESCRIPTION
Added new properties to the default Skeletor configuration:
- allowFontScaling = allows the Text component to scale based on the users' phone settings. defaults to `false`
- maxFontSizeMultiplier = clamps the font size to a maximum multiplier. defaults to `1`
- the above two properties can also be overridden through the `Text` component props on a case by case basis