### PR TITLE
ci: migrate npm publish to Trusted Publishers (OIDC)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -8,31 +8,32 @@ jobs:
   publish-npm:
     runs-on: ubuntu-latest
     environment: NPM
+    permissions:
+      id-token: write
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
 
       - name: Enable Corepack
         run: corepack enable
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 23.4.0
           cache: "yarn"
+          registry-url: "https://registry.npmjs.org"
 
       - run: yarn
 
-      - run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> ~/.npmrc
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_AUTOMATION_TOKEN }}
+      - name: Update npm to Trusted-Publisher-capable version
+        run: npm install -g npm@latest
 
-      # Standard release (no beta or rc)
       - name: Publish standard release
         if: "!(contains(github.event.release.tag_name, 'beta') || contains(github.event.release.tag_name, 'rc'))"
-        run: yarn publish
+        run: npm publish --provenance
 
-      # Pre-release (betaX or rcX)
       - name: Publish pre-release (beta/rc)
         if: "contains(github.event.release.tag_name, 'beta') || contains(github.event.release.tag_name, 'rc')"
-        run: yarn publish --tag next
+        run: npm publish --provenance --tag next


### PR DESCRIPTION
## Summary

- Remove `NPM_AUTOMATION_TOKEN` `.npmrc` write; authenticate to npm via OIDC using npm Trusted Publishers
- Add `permissions: id-token: write` (and explicit `contents: read`) to the publish job
- Bump `actions/checkout` and `actions/setup-node` from v4 to v6
- Add `registry-url: https://registry.npmjs.org` to `setup-node` so OIDC token exchange targets the right registry
- Install `npm@latest` before publishing (Trusted Publisher / provenance requires a recent npm)
- Switch publish command from `yarn publish` to `npm publish --provenance` for both standard and `beta`/`rc` (`--tag next`) releases — Yarn Classic 1.x cannot generate provenance attestations

Yarn is still used for `yarn install`. Lifecycle scripts and the resulting tarball are unchanged.

## Required setup before merge

- [ ] Configure the Trusted Publisher entry on npmjs.com for `@prototyp/skeletor`:
  - Organization / owner: `prototypdigital`
  - Repository: `skeletor`
  - Workflow filename: `npm-publish.yml`
  - Environment: `NPM`
- [ ] Keep the `NPM_AUTOMATION_TOKEN` repo/environment secret in place until the first OIDC publish succeeds, then revoke it on npmjs.com and delete the secret here

## Test plan

- [ ] Cut a prerelease tag (e.g. `vX.Y.Z-rc0`) and publish a GitHub Release as a dry run; verify the workflow authenticates via OIDC and `npm publish --provenance --tag next` succeeds
- [ ] Verify the provenance / "Published from GitHub Actions" badge appears on the published version on npmjs.com
- [ ] Revoke the legacy `NPM_AUTOMATION_TOKEN` on npmjs.com and remove the secret from this repo